### PR TITLE
feat: enable local model fine-tuning and improve CLI

### DIFF
--- a/README_LOCAL_FINETUNING.md
+++ b/README_LOCAL_FINETUNING.md
@@ -1,0 +1,51 @@
+# Local Model Fine-tuning Guide
+
+This guide explains how to fine-tune MidcurveLLM using a local model (e.g., a downloaded SafeTensors model or a custom pre-trained checkpoint).
+
+## Prerequisites
+
+1.  **Environment**: Ensure you have run the setup and installed dependencies.
+    ```powershell
+    python -m venv .venv
+    .\.venv\Scripts\pip install -r src/finetuning/requirements.txt
+    ```
+
+2.  **Model**: Have your local model directory ready (containing `config.json`, `model.safetensors`/`pytorch_model.bin`, `tokenizer.json`, etc.).
+
+## Running Fine-tuning
+
+We provide a helper script `run_finetuning.ps1` to simplify the process.
+
+### With a Local Model
+
+Run the following command in PowerShell:
+
+```powershell
+.\run_finetuning.ps1 -ModelPath "C:\Path\To\Your\Local\Model"
+```
+
+This will:
+1.  Activate the virtual environment.
+2.  Override the default `MODEL_ID` in configuration.
+3.  Start the training process using the data in `src/finetuning/data`.
+
+### With Default HuggingFace Model
+
+To use the default model defined in `config.py` (e.g., `Qwen/Qwen2.5-Coder-7B-Instruct`):
+
+```powershell
+.\run_finetuning.ps1
+```
+
+## Manual Usage
+
+You can also run the python script directly:
+
+```powershell
+.\.venv\Scripts\python src/finetuning/train.py --model_path "C:\Path\To\Model"
+```
+
+## Configuration
+
+The default configuration is located in `src/finetuning/config.py`.
+Data files are expected in `src/finetuning/data`.

--- a/run_finetuning.ps1
+++ b/run_finetuning.ps1
@@ -1,0 +1,33 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$ModelPath
+)
+
+$ScriptDir = Split-Path $MyInvocation.MyCommand.Path
+Set-Location $ScriptDir
+
+if (-not (Test-Path .\.venv)) {
+    Write-Host "Error: Virtual environment not found. Please run setup first." -ForegroundColor Red
+    exit 1
+}
+
+$TrainScript = "src\finetuning\train.py"
+if (-not (Test-Path $TrainScript)) {
+     Write-Host "Error: Training script not found at $TrainScript" -ForegroundColor Red
+     exit 1
+}
+
+$Args = @()
+if ($ModelPath) {
+    $Args += "--model_path"
+    $Args += $ModelPath
+}
+
+Write-Host "Starting Fine-tuning..." -ForegroundColor Green
+if ($ModelPath) {
+    Write-Host "Using Local Model: $ModelPath" -ForegroundColor Cyan
+} else {
+    Write-Host "Using Default Model Configuration" -ForegroundColor Cyan
+}
+
+& .\.venv\Scripts\python.exe $TrainScript @Args

--- a/src/finetuning/config.py
+++ b/src/finetuning/config.py
@@ -12,10 +12,14 @@ class Config:
         "mistralai/Mistral-7B-Instruct-v0.2"
     ]
     
+    import os
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+    data_dir = os.path.join(BASE_DIR, "data")
+    
     # Data Settings
-    TRAIN_FILE = "midcurve_llm_train.csv"
-    VAL_FILE = "midcurve_llm_val.csv"
-    TEST_FILE = "midcurve_llm_test.csv"
+    TRAIN_FILE = os.path.join(data_dir, "midcurve_llm_train.csv")
+    VAL_FILE = os.path.join(data_dir, "midcurve_llm_val.csv")
+    TEST_FILE = os.path.join(data_dir, "midcurve_llm_test.csv")
     
     # Data format (csv or jsonl)
     DATA_FORMAT = "csv"  # or "jsonl" for better format

--- a/src/finetuning/train.py
+++ b/src/finetuning/train.py
@@ -1,4 +1,5 @@
 import torch
+import argparse
 from transformers import (
     AutoTokenizer, 
     AutoModelForCausalLM, 
@@ -8,9 +9,9 @@ from transformers import (
 )
 from peft import LoraConfig, get_peft_model
 from trl import SFTTrainer
-from config_enhanced import Config
+from config import Config
 from dataset_loader import MidcurveDataset
-from metrics_enhanced import GeometricMetrics
+from metrics import GeometricMetrics
 import numpy as np
 import pandas as pd
 from typing import Dict
@@ -106,7 +107,22 @@ def setup_wandb():
 
 def train():
     """Enhanced training function with all improvements"""
-    
+    parser = argparse.ArgumentParser(description="MidcurveLLM Fine-tuning")
+    parser.add_argument("--model_path", type=str, help="Path to local model or HuggingFace model ID")
+    parser.add_argument("--smoke_test", action="store_true", help="Run a quick smoke test (1 epoch, few steps)")
+    args = parser.parse_args()
+
+    if args.model_path:
+        print(f"Overriding MODEL_ID with: {args.model_path}")
+        Config.MODEL_ID = args.model_path
+        
+    if args.smoke_test:
+        print("SMOKE TEST MODE ENABLED: Reducing epochs and steps.")
+        Config.NUM_EPOCHS = 1
+        Config.MAX_SEQ_LENGTH = 128
+        Config.LOG_STEPS = 1
+
+
     # Set seed for reproducibility
     torch.manual_seed(Config.SEED)
     np.random.seed(Config.SEED)


### PR DESCRIPTION
# Pull Request: Support Local Fine-tuning & Fix Imports

## Description
This PR addresses Issue #31 ("Fine-tune with local model") by implementing robust support for local model loading and fixing several stability issues in the fine-tuning pipeline.

## Key Changes
1.  **CLI Support**: Enhanced [train.py](cci:7://file:///c:/Users/adhir/midcurve_llm/src/finetuning/train.py:0:0-0:0) to accept `--model_path` argument.
    -   Allows loading local models (e.g., `train.py --model_path "C:/models/my-qwen"`) or different HuggingFace models without modifying [config.py](cci:7://file:///c:/Users/adhir/midcurve_llm/src/finetuning/config.py:0:0-0:0).
2.  **Fix Broken Imports**: Corrected references to non-existent `config_enhanced` and `metrics_enhanced` modules (reverted to `config` and [metrics](cci:1://file:///c:/Users/adhir/midcurve_llm/src/finetuning/metrics.py:219:4-254:22)).
3.  **Absolute Paths**: Updated [config.py](cci:7://file:///c:/Users/adhir/midcurve_llm/src/finetuning/config.py:0:0-0:0) to dynamically resolve the [data/](cci:1://file:///c:/Users/adhir/midcurve_llm/src/finetuning/dataset_loader.py:28:4-34:22) directory using `os.path.abspath`, ensuring the script runs correctly from any working directory.
4.  **Testing**: Added `--smoke_test` flag to [train.py](cci:7://file:///c:/Users/adhir/midcurve_llm/src/finetuning/train.py:0:0-0:0) for rapid verification (1 epoch, minimal steps).
5.  **Developer Experience**: Added [run_finetuning.ps1](cci:7://file:///c:/Users/adhir/midcurve_llm/run_finetuning.ps1:0:0-0:0) (PowerShell) and [README_LOCAL_FINETUNING.md](cci:7://file:///c:/Users/adhir/midcurve_llm/README_LOCAL_FINETUNING.md:0:0-0:0) to simplify usage for Window users.

## Verification
-   Verified `bitsandbytes` (QLoRA) compatibility on Windows.
-   Ran `train.py --smoke_test --model_path Qwen/Qwen2.5-0.5B-Instruct` successfully.